### PR TITLE
Feature/1201590612941083 evm integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,21 +25,21 @@ version = '2.0.0'
 
 [dependencies.frame-benchmarking]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
+git = 'https://github.com/purestake/substrate'
 optional = true
-tag = 'monthly-2021-10'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -49,32 +49,32 @@ version = '1.0'
 
 [dependencies.sp-runtime]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-core]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-io]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'  # or the latest monthly
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'  # or the latest monthly
 version = '4.0.0-dev'    # or the latest version
 
 [dependencies.pallet-timestamp]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'  # or the latest monthly
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'  # or the latest monthly
 version = '4.0.0-dev'    # or the latest version
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,21 +25,21 @@ version = '2.0.0'
 
 [dependencies.frame-benchmarking]
 default-features = false
-git = 'https://github.com/purestake/substrate'
+git = 'https://github.com/peaqnetwork/substrate'
 optional = true
-branch = 'moonbeam-polkadot-v0.9.13'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -49,32 +49,32 @@ version = '1.0'
 
 [dependencies.sp-runtime]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-core]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-io]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'  # or the latest monthly
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'  # or the latest monthly
 version = '4.0.0-dev'    # or the latest version
 
 [dependencies.pallet-timestamp]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'  # or the latest monthly
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'  # or the latest monthly
 version = '4.0.0-dev'    # or the latest version
 
 [features]


### PR DESCRIPTION
Change the dependent libraries to peaq related projects. Because when we want to build the EVM compatible node, we have to make sure all pallets use the same libraries.