### PR TITLE
Fix/1203198015454524 validate valid for parameter

### DIFF
--- a/src/did.rs
+++ b/src/did.rs
@@ -1,31 +1,32 @@
 use crate::structs::*;
 
 pub enum DidError {
-	NotFound,
-	AuthorizationFailed,
-	NameExceedMaxChar,
-	FailedCreate,
-	FailedUpdate,
-	AlreadyExist,
+    NotFound,
+    AuthorizationFailed,
+    NameExceedMaxChar,
+    FailedCreate,
+    FailedUpdate,
+    AlreadyExist,
+    MaxBlockNumberExceeded,
 }
 
 pub trait Did<AccountId, BlockNumber, Moment> {
-	fn is_owner(owner: &AccountId, did_address: &AccountId) -> Result<(), DidError>;
-	fn create(
-		owner: &AccountId,
-		did_address: &AccountId,
-		name: &[u8],
-		value: &[u8],
-		valid_for: Option<BlockNumber>,
-	) -> Result<(), DidError>;
-	fn update(
-		owner: &AccountId,
-		did_address: &AccountId,
-		name: &[u8],
-		value: &[u8],
-		valid_for: Option<BlockNumber>,
-	) -> Result<(), DidError>;
-	fn read(did_address: &AccountId, name: &[u8]) -> Option<Attribute<BlockNumber, Moment>>;
-	fn delete(owner: &AccountId, did_address: &AccountId, name: &[u8]) -> Result<(), DidError>;
-	fn get_hashed_key_for_attr(did_account: &AccountId, name: &[u8]) -> [u8; 32];
+    fn is_owner(owner: &AccountId, did_address: &AccountId) -> Result<(), DidError>;
+    fn create(
+        owner: &AccountId,
+        did_address: &AccountId,
+        name: &[u8],
+        value: &[u8],
+        valid_for: Option<BlockNumber>,
+    ) -> Result<(), DidError>;
+    fn update(
+        owner: &AccountId,
+        did_address: &AccountId,
+        name: &[u8],
+        value: &[u8],
+        valid_for: Option<BlockNumber>,
+    ) -> Result<(), DidError>;
+    fn read(did_address: &AccountId, name: &[u8]) -> Option<Attribute<BlockNumber, Moment>>;
+    fn delete(owner: &AccountId, did_address: &AccountId, name: &[u8]) -> Result<(), DidError>;
+    fn get_hashed_key_for_attr(did_account: &AccountId, name: &[u8]) -> [u8; 32];
 }

--- a/src/did.rs
+++ b/src/did.rs
@@ -8,8 +8,6 @@ pub enum DidError {
     FailedUpdate,
     AlreadyExist,
     MaxBlockNumberExceeded,
-    InvalidSuppliedValue,
-    ParseError,
 }
 
 pub trait Did<AccountId, BlockNumber, Moment> {

--- a/src/did.rs
+++ b/src/did.rs
@@ -8,6 +8,8 @@ pub enum DidError {
     FailedUpdate,
     AlreadyExist,
     MaxBlockNumberExceeded,
+    InvalidSuppliedValue,
+    ParseError,
 }
 
 pub trait Did<AccountId, BlockNumber, Moment> {

--- a/src/did.rs
+++ b/src/did.rs
@@ -29,4 +29,5 @@ pub trait Did<AccountId, BlockNumber, Moment> {
     fn read(did_address: &AccountId, name: &[u8]) -> Option<Attribute<BlockNumber, Moment>>;
     fn delete(owner: &AccountId, did_address: &AccountId, name: &[u8]) -> Result<(), DidError>;
     fn get_hashed_key_for_attr(did_account: &AccountId, name: &[u8]) -> [u8; 32];
+    fn validate_block_number(valid_for: Option<BlockNumber>) -> Result<BlockNumber, DidError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,13 +405,17 @@ pub mod pallet {
                 Some(blocks) => {
                     let now_block_number = <frame_system::Pallet<T>>::block_number();
 
-                    let validity = now_block_number + blocks;
-
-                    if validity > max_block {
+                    if blocks > max_block {
                         return Err(DidError::MaxBlockNumberExceeded);
                     };
 
-                    validity
+                    let new_validity = now_block_number + blocks;
+
+                    if new_validity > max_block {
+                        return Err(DidError::MaxBlockNumberExceeded);
+                    };
+
+                    new_validity
                 }
                 None => max_block,
             };

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -27,6 +27,7 @@ frame_support::construct_runtime!(
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const SS58Prefix: u8 = 42;
+
 }
 
 impl system::Config for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -27,6 +27,7 @@ frame_support::construct_runtime!(
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const SS58Prefix: u8 = 42;
+    pub const BlockNumber: u64 = 5;
 
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,174 +1,210 @@
+use crate::did::Did;
 use crate::{mock::*, Error};
 use frame_support::{assert_noop, assert_ok};
 use hex_literal::hex;
-use crate::did::Did;
 
 #[test]
 fn add_attribute_test() {
-	new_test_ext().execute_with(|| {
-		let acct = "Iredia";
-		let acct2 = "Iredia2";
-		let origin = account_key(acct);
-		let did_account = account_key(acct2);
-		let name = b"id";
-		let attribute = b"did:pq:1234567890";
+    new_test_ext().execute_with(|| {
+        let acct = "Iredia";
+        let acct2 = "Iredia2";
+        let origin = account_key(acct);
+        let did_account = account_key(acct2);
+        let name = b"id";
+        let attribute = b"did:pq:1234567890";
 
-		assert_ok!(PeaqDID::add_attribute(
-			Origin::signed(origin),
-			did_account,
-			name.to_vec(),
-			attribute.to_vec(),
-			None
-		));
+        assert_ok!(PeaqDID::add_attribute(
+            Origin::signed(origin),
+            did_account,
+            name.to_vec(),
+            attribute.to_vec(),
+            None
+        ));
 
-		// Test for duplicate entry
-		assert_noop!(
-			PeaqDID::add_attribute(
-				Origin::signed(origin),
-				did_account,
-				name.to_vec(),
-				attribute.to_vec(),
-				None
-			),
-			Error::<Test>::AttributeAlreadyExist
-		);
-	});
+        // Test for duplicate entry
+        assert_noop!(
+            PeaqDID::add_attribute(
+                Origin::signed(origin),
+                did_account,
+                name.to_vec(),
+                attribute.to_vec(),
+                None
+            ),
+            Error::<Test>::AttributeAlreadyExist
+        );
+
+        // Test update did attribute with invalid validity
+        assert_noop!(
+            PeaqDID::add_attribute(
+                Origin::signed(origin),
+                did_account,
+                b"name".to_vec(),
+                attribute.to_vec(),
+                Some(12345678989585857589_u64),
+            ),
+            Error::<Test>::MaxBlockNumberExceeded
+        );
+    });
 }
 
 #[test]
 fn update_attribute_test() {
-	new_test_ext().execute_with(|| {
-		let acct = "Iredia";
-		let acct2 = "Iredia2";
-		let acct3 = "Fake";
-		let origin = account_key(acct);
-		let did_account = account_key(acct2);
-		let fake_origin = account_key(acct3);
-		let name = b"id";
-		let attribute = b"did:pq:1234567890";
+    new_test_ext().execute_with(|| {
+        let acct = "Iredia";
+        let acct2 = "Iredia2";
+        let acct3 = "Fake";
+        let origin = account_key(acct);
+        let did_account = account_key(acct2);
+        let fake_origin = account_key(acct3);
+        let name = b"id";
+        let attribute = b"did:pq:1234567890";
 
-		assert_ok!(PeaqDID::add_attribute(
-			Origin::signed(origin),
-			did_account,
-			name.to_vec(),
-			attribute.to_vec(),
-			None
-		));
+        assert_ok!(PeaqDID::add_attribute(
+            Origin::signed(origin),
+            did_account,
+            name.to_vec(),
+            attribute.to_vec(),
+            None
+        ));
 
-		// Test update owner did attribute
-		assert_ok!(PeaqDID::update_attribute(
-			Origin::signed(origin),
-			did_account,
-			name.to_vec(),
-			attribute.to_vec(),
-			None,
-		));
+        // Test update owner did attribute
+        assert_ok!(PeaqDID::update_attribute(
+            Origin::signed(origin),
+            did_account,
+            name.to_vec(),
+            attribute.to_vec(),
+            None,
+        ));
 
-		// Test update another owner did attribute
-		assert_noop!(
-			PeaqDID::update_attribute(
-				Origin::signed(fake_origin),
-				did_account,
-				name.to_vec(),
-				attribute.to_vec(),
-				None,
-			),
-			Error::<Test>::AttributeAuthorizationFailed
-		);
+        // Test update did attribute with invalid validity
+        assert_noop!(
+            PeaqDID::update_attribute(
+                Origin::signed(origin),
+                did_account,
+                name.to_vec(),
+                attribute.to_vec(),
+                Some(12345678989585857589_u64),
+            ),
+            Error::<Test>::MaxBlockNumberExceeded
+        );
 
-		// Test update non-existing attribute
-		assert_noop!(
-			PeaqDID::update_attribute(
-				Origin::signed(origin),
-				did_account,
-				b"name".to_vec(),
-				attribute.to_vec(),
-				None,
-			),
-			Error::<Test>::AttributeNotFound
-		);
-	});
+        // Test update another owner did attribute
+        assert_noop!(
+            PeaqDID::update_attribute(
+                Origin::signed(fake_origin),
+                did_account,
+                name.to_vec(),
+                attribute.to_vec(),
+                None,
+            ),
+            Error::<Test>::AttributeAuthorizationFailed
+        );
+
+        // Test update non-existing attribute
+        assert_noop!(
+            PeaqDID::update_attribute(
+                Origin::signed(origin),
+                did_account,
+                b"name".to_vec(),
+                attribute.to_vec(),
+                None,
+            ),
+            Error::<Test>::AttributeNotFound
+        );
+    });
 }
 
 #[test]
 fn read_attribute_test() {
-	new_test_ext().execute_with(|| {
-		let acct = "Iredia";
-		let acct2 = "Iredia2";
-		let origin = account_key(acct);
-		let did_account = account_key(acct2);
-		let name = b"id";
-		let attribute = b"did:pq:1234567890";
+    new_test_ext().execute_with(|| {
+        let acct = "Iredia";
+        let acct2 = "Iredia2";
+        let origin = account_key(acct);
+        let did_account = account_key(acct2);
+        let name = b"id";
+        let attribute = b"did:pq:1234567890";
 
-		assert_ok!(PeaqDID::add_attribute(
-			Origin::signed(origin),
-			did_account,
-			name.to_vec(),
-			attribute.to_vec(),
-			None
-		));
+        assert_ok!(PeaqDID::add_attribute(
+            Origin::signed(origin),
+            did_account,
+            name.to_vec(),
+            attribute.to_vec(),
+            None
+        ));
 
-		// Test read existing attribute
-		assert_ok!(PeaqDID::read_attribute(Origin::signed(origin), did_account, name.to_vec()));
+        // Test read existing attribute
+        assert_ok!(PeaqDID::read_attribute(
+            Origin::signed(origin),
+            did_account,
+            name.to_vec()
+        ));
 
-		// Test read non-existing attribute
-		assert_noop!(
-			PeaqDID::read_attribute(Origin::signed(origin), account_key("invalid"), name.to_vec()),
-			Error::<Test>::AttributeNotFound
-		);
-	});
+        // Test read non-existing attribute
+        assert_noop!(
+            PeaqDID::read_attribute(
+                Origin::signed(origin),
+                account_key("invalid"),
+                name.to_vec()
+            ),
+            Error::<Test>::AttributeNotFound
+        );
+    });
 }
 
 #[test]
 fn remove_attribute_test() {
-	new_test_ext().execute_with(|| {
-		let acct = "Iredia";
-		let acct2 = "Iredia2";
-		let acct3 = "Fake";
-		let origin = account_key(acct);
-		let did_account = account_key(acct2);
-		let fake_origin = account_key(acct3);
-		let name = b"id";
-		let attribute = b"did:pq:1234567890";
+    new_test_ext().execute_with(|| {
+        let acct = "Iredia";
+        let acct2 = "Iredia2";
+        let acct3 = "Fake";
+        let origin = account_key(acct);
+        let did_account = account_key(acct2);
+        let fake_origin = account_key(acct3);
+        let name = b"id";
+        let attribute = b"did:pq:1234567890";
 
-		assert_ok!(PeaqDID::add_attribute(
-			Origin::signed(origin),
-			did_account,
-			name.to_vec(),
-			attribute.to_vec(),
-			None
-		));
+        assert_ok!(PeaqDID::add_attribute(
+            Origin::signed(origin),
+            did_account,
+            name.to_vec(),
+            attribute.to_vec(),
+            None
+        ));
 
-		// Test remove owner did attribute
-		assert_ok!(PeaqDID::remove_attribute(Origin::signed(origin), did_account, name.to_vec()));
+        // Test remove owner did attribute
+        assert_ok!(PeaqDID::remove_attribute(
+            Origin::signed(origin),
+            did_account,
+            name.to_vec()
+        ));
 
-		// Test remove another owner did attribute
-		assert_noop!(
-			PeaqDID::remove_attribute(Origin::signed(fake_origin), did_account, name.to_vec()),
-			Error::<Test>::AttributeAuthorizationFailed
-		);
+        // Test remove another owner did attribute
+        assert_noop!(
+            PeaqDID::remove_attribute(Origin::signed(fake_origin), did_account, name.to_vec()),
+            Error::<Test>::AttributeAuthorizationFailed
+        );
 
-		// Test remove non-existing attribute
-		assert_noop!(
-			PeaqDID::remove_attribute(Origin::signed(origin), did_account, b"name".to_vec()),
-			Error::<Test>::AttributeNotFound
-		);
-	});
+        // Test remove non-existing attribute
+        assert_noop!(
+            PeaqDID::remove_attribute(Origin::signed(origin), did_account, b"name".to_vec()),
+            Error::<Test>::AttributeNotFound
+        );
+    });
 }
 
 #[test]
 fn hashed_key_correctness_test() {
-	
-	new_test_ext().execute_with(||{
+    new_test_ext().execute_with(|| {
+        let did_account = sp_core::sr25519::Public::from_raw(hex!(
+            "6031188a7c447201a20c044b5e93a6857683a0186a2e02c799974c94a6e4331d"
+        ));
+        let name = b"id";
+        let expected_result =
+            hex!("01621935bef7de2129d77df46f9fc533054dbc82b03df3f4f0ac1ebeab878919");
 
-		let did_account = sp_core::sr25519::Public::from_raw(
-			hex!("6031188a7c447201a20c044b5e93a6857683a0186a2e02c799974c94a6e4331d"));
-		let name = b"id";
-		let expected_result = hex!("01621935bef7de2129d77df46f9fc533054dbc82b03df3f4f0ac1ebeab878919");
-
-		assert_eq!(PeaqDID::get_hashed_key_for_attr(
-			&did_account,
-			&name[..]
-		), expected_result)
-	});
+        assert_eq!(
+            PeaqDID::get_hashed_key_for_attr(&did_account, &name[..]),
+            expected_result
+        )
+    });
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -40,9 +40,9 @@ fn add_attribute_test() {
                 did_account,
                 b"name".to_vec(),
                 attribute.to_vec(),
-                Some(12345678989585857589_u64),
+                Some(4294967299999996_u64),
             ),
-            Error::<Test>::MaxBlockNumberExceeded
+            Error::<Test>::InvalidSuppliedValue
         );
     });
 }
@@ -85,7 +85,7 @@ fn update_attribute_test() {
                 attribute.to_vec(),
                 Some(12345678989585857589_u64),
             ),
-            Error::<Test>::MaxBlockNumberExceeded
+            Error::<Test>::InvalidSuppliedValue
         );
 
         // Test update another owner did attribute

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,8 @@ use hex_literal::hex;
 #[test]
 fn add_attribute_test() {
     new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
         let acct = "Iredia";
         let acct2 = "Iredia2";
         let origin = account_key(acct);
@@ -40,9 +42,9 @@ fn add_attribute_test() {
                 did_account,
                 b"name".to_vec(),
                 attribute.to_vec(),
-                Some(4294967299999996_u64),
+                Some(u64::max_value()),
             ),
-            Error::<Test>::InvalidSuppliedValue
+            Error::<Test>::MaxBlockNumberExceeded
         );
     });
 }
@@ -50,6 +52,8 @@ fn add_attribute_test() {
 #[test]
 fn update_attribute_test() {
     new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
         let acct = "Iredia";
         let acct2 = "Iredia2";
         let acct3 = "Fake";
@@ -83,9 +87,9 @@ fn update_attribute_test() {
                 did_account,
                 name.to_vec(),
                 attribute.to_vec(),
-                Some(12345678989585857589_u64),
+                Some(u64::max_value()),
             ),
-            Error::<Test>::InvalidSuppliedValue
+            Error::<Test>::MaxBlockNumberExceeded
         );
 
         // Test update another owner did attribute


### PR DESCRIPTION
03. Security audit fixes:
* added block number validation on update extrinsics
* added block number validation on create extrinsics
* added validation unit tests
* validation function code refactoring

REF:
03. [High] Integer overflows in peaq-pallet-
did
Summary:
In the peaq-pallet-did pallet, the extrinsic add_attribute has an 
optional valid_for parameter, that adds itself to the current block 
number which can overflow if the provided value is sufficiently high. 
The same issue also exists for the create in a similar fashion.

Risk:
By exploiting this integer overflow, an attacker could:

Crash any node compiled in debug mode or with overflow checks
enabled.
On nodes that are compiled without overflow checks, this will 
lead to unexpected behaviors and logic inconsistencies.

Mitigation
Use safe math functions or perform overflow checks while doing math 
operations