### PR TITLE
fix(read_attribute): make block hash parameter optional

### DIFF
--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -370,7 +370,7 @@ pub mod pallet {
 
             let new_attribute = Attribute {
                 name: bounded_name,
-                value: value,
+                value,
                 validity,
                 created: now_timestamp,
             };

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -48,7 +48,7 @@ pub trait PeaqDIDApi<BlockHash, AccountId, BlockNumber, Moment> {
         &self,
         did_account: AccountId,
         name: Bytes,
-        at: BlockHash,
+        at: Option<BlockHash>,
     ) -> RpcResult<Option<RPCAttribute<BlockNumber, Moment>>>;
 }
 
@@ -95,10 +95,11 @@ where
         &self,
         did_account: AccountId,
         name: Bytes,
-        at: <Block as BlockT>::Hash,
+        at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Option<RPCAttribute<BlockNumber, Moment>>> {
         let api = self.client.runtime_api();
-        api.read(at, did_account, name.to_vec())
+        let block_hash = at.unwrap_or_else(|| self.client.info().best_hash);
+        api.read(block_hash, did_account, name.to_vec())
             .map(|o| o.map(RPCAttribute::from))
             .map_err(|err| internal_err(err.to_string()))
     }


### PR DESCRIPTION
This PR is fixing the error where we cannot call rpc to read an attribute. This was happening because the parameter `at` that was referring to the block hash was not optional and so was failing if we didn't provided it. This was not happening on the different tests that we have because it was an issue about rpc only.